### PR TITLE
Add brand detail crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # saketime_crawler
-This is a crawler that collect data frome a well-known ranking website of Japanese sake
+
+This repository contains simple crawlers for the Japanese sake ranking site "Saketime". The data for all regions is already bundled in `saketime_all_regions.csv`.
+
+## Crawling brand details
+
+To fetch information from each brand's detail page, run the helper
+function defined in `brand_detail_crawler.py`:
+
+```python
+from brand_detail_crawler import crawl_brands_from_csv
+
+crawl_brands_from_csv()
+```
+
+The function reads the URLs from `saketime_all_regions.csv`, crawls the
+pages and saves a new file `saketime_brand_details.csv` with the parsed
+information.

--- a/brand_detail_crawler.py
+++ b/brand_detail_crawler.py
@@ -1,0 +1,89 @@
+import csv
+import time
+import random
+from typing import Dict, List, Optional
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+
+def crawl_brand_detail(url: str) -> Optional[Dict[str, str]]:
+    """Crawl sake brand detail page and return parsed information.
+
+    Parameters
+    ----------
+    url : str
+        Detail page URL.
+
+    Returns
+    -------
+    Optional[Dict[str, str]]
+        Parsed brand information or None if request fails.
+    """
+    headers = {"User-Agent": "Mozilla/5.0"}
+    try:
+        res = requests.get(url, headers=headers, timeout=15)
+        res.raise_for_status()
+    except Exception:
+        return None
+
+    soup = BeautifulSoup(res.text, "html.parser")
+
+    title_tag = soup.find("meta", property="og:title")
+    desc_tag = soup.find("meta", property="og:description")
+
+    brand_name = title_tag["content"].strip() if title_tag else ""
+    description = desc_tag["content"].strip() if desc_tag else ""
+
+    prefecture = ""
+    brewery = ""
+
+    info_table = soup.select_one("table")
+    if info_table:
+        for tr in info_table.select("tr"):
+            th = tr.select_one("th")
+            td = tr.select_one("td")
+            if not th or not td:
+                continue
+            key = th.text.strip()
+            val = td.text.strip()
+            if "地域" in key or "都道府県" in key:
+                prefecture = val
+            elif "蔵元" in key or "酒造" in key:
+                brewery = val
+
+    return {
+        "brand_name": brand_name,
+        "prefecture": prefecture,
+        "brewery": brewery,
+        "description": description,
+    }
+
+
+def crawl_brands_from_csv(csv_path: str = "saketime_all_regions.csv", output_csv: str = "saketime_brand_details.csv") -> None:
+    """Crawl brand detail pages listed in ``csv_path`` and save to ``output_csv``.
+
+    Parameters
+    ----------
+    csv_path : str
+        Path to ``saketime_all_regions.csv`` that contains URLs under the ``詳細頁面連結`` column.
+    output_csv : str
+        Destination path of the crawled data.
+    """
+    df = pd.read_csv(csv_path)
+
+    results: List[Dict[str, str]] = []
+    for _, row in df.iterrows():
+        url = row.get("詳細頁面連結")
+        if not isinstance(url, str) or not url:
+            continue
+        info = crawl_brand_detail(url)
+        if info:
+            info["URL"] = url
+            results.append(info)
+        time.sleep(random.uniform(1.5, 3.0))
+
+    if results:
+        pd.DataFrame(results).to_csv(output_csv, index=False, encoding="utf-8-sig")
+


### PR DESCRIPTION
## Summary
- introduce `brand_detail_crawler.py` with functions to parse each brand detail page
- document how to use the new crawler in `README.md`

## Testing
- `python -m py_compile brand_detail_crawler.py`
- `pip install pandas` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e3b87ed70832b9d0e710399d93248